### PR TITLE
added .cb_list_cohorts_v2 for CBv2 endpoints

### DIFF
--- a/R/cb_cohorts_list.R
+++ b/R/cb_cohorts_list.R
@@ -52,11 +52,15 @@ cb_list_cohorts <- function(size = 10, cb_version = "v2") {
     description = cohorts[[n]]$description
     if(is.null(description)) description = "" # change everything to ""
     
+    # For no filters backend returns NULL
+    numberOfFilters <- cohorts[[n]]$numberOfFilters
+    if(is.null(numberOfFilters)) numberOfFilters <- 0    
+    
     dta <- data.frame(id = cohorts[[n]]$`_id`,
                       name = cohorts[[n]]$name,
                       description = description,
                       number_of_participants = cohorts[[n]]$numberOfParticipants,
-                      number_of_filters = cohorts[[n]]$numberOfFilters,
+                      number_of_filters = numberOfFilters,
                       created_at = cohorts[[n]]$createdAt,
                       updated_at = cohorts[[n]]$updatedAt)
     cohorts_list[[n]] <- dta

--- a/R/cb_cohorts_list.R
+++ b/R/cb_cohorts_list.R
@@ -3,6 +3,8 @@
 #' @description Extracts the data frame with limited cohort data columns.
 #'
 #' @param size Number of cohort entries from database. (Optional) Default - 10
+#' @param cb_version cohort browser version. ["v1" | "v2"] (Optional) Default - "v2"
+
 #'
 #' @return A data frame with available cohorts.
 #'
@@ -11,7 +13,22 @@
 #' cohorts_list()
 #' }
 #' @export
-cb_list_cohorts <- function(size = 10) {
+cb_list_cohorts <- function(size = 10, cb_version = "v2") {
+  
+  if (cb_version == "v1") {
+    return(.cb_list_cohorts_v1(size=size))
+    
+  } else if (cb_version == "v2") {
+    return(.cb_list_cohorts_v2(size=size))
+    
+  } else {
+    stop('Unknown cohort browser version string ("cb_version"). Choose either "v1" or "v2".')
+  }
+}
+
+
+.cb_list_cohorts_v1 <- function(size = 10) {
+  
   cloudos <- .check_and_load_all_cloudos_env_var()
   url <- paste(cloudos$base_url, "v1/cohort", sep = "/")
   r <- httr::GET(url,
@@ -40,6 +57,52 @@ cb_list_cohorts <- function(size = 10) {
                       description = description,
                       number_of_participants = cohorts[[n]]$numberOfParticipants,
                       number_of_filters = cohorts[[n]]$numberOfFilters,
+                      created_at = cohorts[[n]]$createdAt,
+                      updated_at = cohorts[[n]]$updatedAt)
+    cohorts_list[[n]] <- dta
+    # filter
+    # cohorts[[1]]$`filters`
+  }
+  # make in to a dataframe
+  cohorts_df <- do.call(rbind, cohorts_list)
+  return(cohorts_df)
+}
+
+
+.cb_list_cohorts_v2 <- function(size = 10) {
+  
+  cloudos <- .check_and_load_all_cloudos_env_var()
+  url <- paste(cloudos$base_url, "v2/cohort", sep = "/")
+  r <- httr::GET(url,
+                 .get_httr_headers(cloudos$token),
+                 query = list("teamId" = cloudos$team_id,
+                              "pageNumber" = 0,
+                              "pageSize" = size))
+  httr::stop_for_status(r, task = "list cohorts")
+  # parse the content
+  res <- httr::content(r)
+  if(size == 10){
+    message("Total number of cohorts found: ", res$total, 
+            ". Showing ",  size," by default. Change 'size' parameter to return more.") 
+  }
+  cohorts <- res$cohorts
+  # make in to a list
+  cohorts_list <- list()
+  for (n in 1:length(cohorts)) {
+    
+    # For empty description backend returns two things NULL and ""
+    description <- cohorts[[n]]$description
+    if(is.null(description)) description <- "" # change everything to ""
+    
+    # For no filters backend returns NULL
+    numberOfFilters <- cohorts[[n]]$numberOfFilters
+    if(is.null(numberOfFilters)) numberOfFilters <- 0
+    
+    dta <- data.frame(id = cohorts[[n]]$`_id`,
+                      name = cohorts[[n]]$name,
+                      description = description,
+                      number_of_participants = cohorts[[n]]$numberOfParticipants,
+                      number_of_filters = numberOfFilters,
                       created_at = cohorts[[n]]$createdAt,
                       updated_at = cohorts[[n]]$updatedAt)
     cohorts_list[[n]] <- dta


### PR DESCRIPTION
## This PR does the following:

+ It adds the function `.cb_list_cohorts_v2()` and renames the old `cb_list_cohorts()` to `.cb_list_cohorts_v1()`.
+ The exported function `cb_list_cohorts()` now calls `.cb_list_cohorts_v1()` or `.cb_list_cohorts_v2()` depending on the CB version specified.

## Testing
Get the package from the PR branch:
```shell
git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
cd cloudos
git checkout cb_list_cohorts_v2
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> cloudos_configure(base_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

test
```
> cohort_listv2 <- cb_list_cohorts(cb_version = "v2")
Total number of cohorts found: 138. Showing 10 by default. Change 'size' parameter to return more.
> cohort_listv2
                         id           name description number_of_participants number_of_filters               created_at
1  60e833e09dd71b22256fcfdb   ilya-r-test2                              44684                 0 2021-07-09T11:32:48.252Z
2  60e5dbf10785d14785a57682        r-test4                              44684                 0 2021-07-07T16:53:05.399Z
3  60e5dbe20785d14785a57681        r-test3                              44684                 0 2021-07-07T16:52:50.180Z
4  60deee78f97e550eda221fee    web-test-01                              44684                 0 2021-07-02T10:46:16.544Z
5  60dedc0df97e550eda221fed        test_02                               5020                 0 2021-07-02T09:27:41.921Z
6  60ded686f97e550eda221fec         test-8                                  0                 0 2021-07-02T09:04:06.148Z
7  60ded64ff97e550eda221feb         test-6                              44684                 0 2021-07-02T09:03:11.455Z
8  60ded198f97e550eda221fea test_cohort_01                              44684                 0 2021-07-02T08:43:04.472Z
9  60d49be883bb7d61d41ee8cb  damiantestasd                              15789                 0 2021-06-24T14:51:20.410Z
10 60d4970b83bb7d61d41ee8ca asdsadsadsadas                               5343                 0 2021-06-24T14:30:35.010Z
                 updated_at
1  2021-07-09T11:32:48.252Z
2  2021-07-07T16:53:05.399Z
3  2021-07-07T16:52:50.180Z
4  2021-07-06T14:37:38.747Z
5  2021-07-06T16:11:27.093Z
6  2021-07-02T09:05:22.628Z
7  2021-07-02T09:03:11.455Z
8  2021-07-02T08:43:04.472Z
9  2021-06-24T14:52:28.409Z
10 2021-06-24T14:32:17.836Z

> cb_list_cohorts(cb_version = "v1")
Total number of cohorts found-51. But here shows-10 as default. For more, change size = 51 to get all.
                         id                name description number_of_participants number_of_filters               created_at
1  60e833cc9dd71b22256fcfda        ilya-r-test1                              44684                 0 2021-07-09T11:32:28.169Z
2  60e5dbfd0785d14785a57683             r-test2                              44684                 0 2021-07-07T16:53:17.999Z
3  60df0170f97e550eda221ff2           r-test-02                              44684                 0 2021-07-02T12:07:12.617Z
4  60def6aef97e550eda221fef           r-test-01                              44684                 0 2021-07-02T11:21:18.532Z
5  60b0d178d4b5e133642e3035   manos text_search                                 67                 0 2021-05-28T11:18:16.154Z
6  609427e554251e0aaffbf922      Filippo_tests2        Tets                   1536                 0 2021-05-06T17:31:17.177Z
7  609427da54251e0aaffbf920       Filippo_test1                              44667                 0 2021-05-06T17:31:06.185Z
8  608bb776c356ca05c38ddd0c     test_migration5                                 11                 0 2021-04-30T07:53:26.788Z
9  608bb657c356ca05c38ddd07    Manos_migration3                                  4                 0 2021-04-30T07:48:39.900Z
10 608b959ef552df10125d3737 Main_cohort_testing                                  6                 0 2021-04-30T05:29:02.384Z
                 updated_at
1  2021-07-09T11:32:28.169Z
2  2021-07-07T16:53:17.999Z
3  2021-07-02T12:07:12.617Z
4  2021-07-02T11:21:18.532Z
5  2021-06-22T17:49:04.930Z
6  2021-05-17T14:32:27.383Z
7  2021-05-06T17:31:06.185Z
8  2021-04-30T07:54:00.027Z
9  2021-04-30T07:49:13.479Z
10 2021-04-30T05:41:50.117Z

```

