### PR TITLE
added .cb_create_cohort_v2 for CBv2 endpoint

### DIFF
--- a/R/cb_cohort_create.R
+++ b/R/cb_cohort_create.R
@@ -5,6 +5,7 @@
 #' @param cohort_name New cohort name to be created. (Required)
 #' @param cohort_desc New cohort description to be created. (Optional)
 #' @param filters WIP - details will be added.
+#' @param cb_version cohort browser version. ["v1" | "v2"] (Optional) Default - "v2"
 #'
 #' @return A \linkS4class{cohort} object.
 #' 
@@ -16,7 +17,21 @@
 #'                               cohort_desc = "This cohort is for testing purpose, created from R.")
 #' }
 #' @export
-cb_create_cohort <- function(cohort_name, cohort_desc, filters = "") {
+cb_create_cohort <- function(cohort_name, cohort_desc, filters = "", cb_version="v2") {
+  
+  if (cb_version == "v1") {
+    return(.cb_create_cohort_v1(cohort_name=cohort_name, cohort_desc=cohort_desc, filters=filters))
+    
+  } else if (cb_version == "v2") {
+    return(.cb_create_cohort_v2(cohort_name=cohort_name, cohort_desc=cohort_desc, filters=filters))
+    
+  } else {
+    stop('Unknown cohort browser version string ("cb_version"). Choose either "v1" or "v2".')
+  }
+}
+
+
+.cb_create_cohort_v1 <- function(cohort_name, cohort_desc, filters = "") {
   
   # if no description provided
   if(missing(cohort_desc)){
@@ -43,3 +58,36 @@ cb_create_cohort <- function(cohort_name, cohort_desc, filters = "") {
   cohort_obj <- cb_load_cohort(cohort_id = res$`_id`)
   return(cohort_obj)
 }
+
+
+.cb_create_cohort_v2 <- function(cohort_name, cohort_desc, filters = "") {
+  
+  # if no description provided
+  if(missing(cohort_desc)){
+    cohort_desc = list()
+  }
+  cloudos <- .check_and_load_all_cloudos_env_var()
+  url <- paste(cloudos$base_url, "v2/cohort/", sep = "/")
+  r <- httr::POST(url,
+                  .get_httr_headers(cloudos$token),
+                  query = list("teamId" = cloudos$team_id),
+                  body = list("name" = cohort_name,
+                              "description" = cohort_desc, 
+                              "moreFilters" = filters), # TODO work on filters - its better to do from UI
+                  encode = "json"
+  )
+  httr::stop_for_status(r, task = "create a cohort")
+  # parse the content
+  message("Cohort created successfully.")
+  res <- httr::content(r)
+  # into a dataframe
+  # res_df <- do.call(rbind, res)
+  # colnames(res_df) <- "details"
+  # return a cohort object
+  cohort_obj <- cb_load_cohort(cohort_id = res$`_id`)
+  return(cohort_obj)
+  
+  #TODO check why created cohort is not listed but can be found by ID.
+}
+
+


### PR DESCRIPTION
## This PR does the following:

+ It adds the function `.cb_create_cohort_v2()` and renames the old `cb_create_cohort()` to `.cb_create_cohort_v1()`.
+ The exported function `cb_create_cohort()` now calls `.cb_create_cohort_v1()` or `.cb_create_cohort_v2()` depending on the CB version specified.

## Testing
Ensure you are configured to use the demo cohort browser instance with both CBv1 and CBv2:
```
> cloudos_whoami()
CloudOS base URL http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/
CloudOS token    .....
CloudOS team id  5f7c8696d6ea46288645a89f
```

```
devtools::load_all()
cb_create_cohort("ilya-r-test1", cb_version="v1")
cb_create_cohort("ilya-r-test2", cb_version="v2")
```

