### PR TITLE
added .get_cohort_info_v2 for CBv2 endpoint

### DIFF
--- a/R/cb_class.R
+++ b/R/cb_class.R
@@ -75,6 +75,7 @@ setClass("cohort",
 #' applied filters.
 #'
 #' @param cohort_id Cohort id (Required)
+#' @param cb_version cohort browser version (Optional) [ "v1" | "v2" ]
 #'
 #' @return A \linkS4class{cohort} object.
 #'


### PR DESCRIPTION
## This PR does the following:

+ It adds the function `.get_cohort_info_v2()` and renames the old `.get_cohort_info()` to `.get_cohort_info_v1()`.
+ The exported function `cb_load_cohort()` now calls `.get_cohort_info_v1()` or `.get_cohort_info_v2()` depending on the CB version specified.
+ When using `cb_load_cohort()` with `cb_version = "v2"` argument, the `fields` and `more_fields` slots will be empty. This is to be fixed in a PR to refactor the `cohort` class.

## Testing

Get the package from the PR branch:
```shell
> git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
> cd cloudos
> git checkout get_cohort_info_v2
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> library(cloudos)
> cloudos_configure(base_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

Test that you are able to load the cohorts in v1 and v2:

```R
> cohortv2 <- cb_load_cohort("60dedc0df97e550eda221fed", cb_version = "v2")
> cohortv2
Cohort ID:  60dedc0df97e550eda221fed 
Cohort Name:  test_02 
Cohort Description:   
Number of filters applied:  3 
> length(cohortv2@fields)
[1] 0
> length(cohortv2@more_fields)
[1] 0
> length(cohortv2@columns)
[1] 6

> cohortv1 <- cb_load_cohort("60dedc0df97e550eda221fed", cb_version = "v1")
> cohortv1
Cohort ID:  60dedc0df97e550eda221fed 
Cohort Name:  test_02 
Cohort Description:   
Number of filters applied:  3 
> length(cohortv1@fields)
[1] 3
> length(cohortv1@more_fields)
[1] 3
> length(cohortv1@columns)
[1] 6
```

Note that for V2 cohorts `@fields` and `@more_fields` are left empty. PR #33 changes the slots to make V2 cohorts work as well.

