### PR TITLE
Update cb_get_filter_statistics to v2

### DIFF
--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -63,9 +63,32 @@ cb_search_phenotypic_filters <- function(term){
 #'
 #' @export
 cb_get_filter_statistics <- function(cohort, filter_id ) {
-  # empty moreFilters returns all the filter values associated with a cohort for a filter
-  r_body <- list("filter" = list("instances" = c(0)),
-                 "moreFilters" = list(),
+  if (cohort@cb_version == "v1") {
+    return(.cb_get_filter_statistics_v1(cohort))
+    
+  } else if (cohort@cb_version == "v2") {
+    return(.cb_get_filter_statistics_v2(cohort))
+    
+  } else {
+    stop('Unknown cohort browser version string ("cb_version"). Choose either "v1" or "v2".')
+  }
+}
+
+
+.cb_get_filter_statistics_v1 <- function(cohort, filter_id) {
+
+  # make more_filters from cohort@query
+  more_filters = list() 
+  for (filter in .unnest_query(cohort@query)){
+    if (!is.null(filter$value)){
+      # rename field to fieldId
+      names(filter)[names(filter) == "field"] <- "fieldId"
+      more_filters <- c(more_filters, list(filter))
+    }
+  }
+  
+  r_body <- list("filter" = list("instances" = list("0")),
+                 "moreFilters" = more_filters,
                  "cohortId" = cohort@id
                  )
   cloudos <- .check_and_load_all_cloudos_env_var()
@@ -74,7 +97,31 @@ cb_get_filter_statistics <- function(cohort, filter_id ) {
   r <- httr::POST(url,
                   .get_httr_headers(cloudos$token),
                   query = list("teamId" = cloudos$team_id),
-                  body = jsonlite::toJSON(r_body),
+                  body = jsonlite::toJSON(r_body, auto_unbox = T),
+                  encode = "raw"
+  )
+  httr::stop_for_status(r, task = NULL)
+  # parse the content
+  res <- httr::content(r)
+  # into a dataframe
+  res_df <- dplyr::bind_rows(res)
+  return(res_df)
+}
+
+
+.cb_get_filter_statistics_v2 <- function(cohort, filter_id) {
+  # empty moreFilters returns all the filter values associated with a cohort for a filter
+  r_body <- list("criteria" = list("cohortId" = cohort@id),
+                 "filter" = list("instance" = list("0")),
+                 "query" = cohort@query
+                 )
+  cloudos <- .check_and_load_all_cloudos_env_var()
+  # make request
+  url <- paste(cloudos$base_url, "v2/cohort/filter", filter_id, "data", sep = "/")
+  r <- httr::POST(url,
+                  .get_httr_headers(cloudos$token),
+                  query = list("teamId" = cloudos$team_id),
+                  body = jsonlite::toJSON(r_body, auto_unbox = T),
                   encode = "raw"
   )
   httr::stop_for_status(r, task = NULL)

--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -64,10 +64,10 @@ cb_search_phenotypic_filters <- function(term){
 #' @export
 cb_get_filter_statistics <- function(cohort, filter_id ) {
   if (cohort@cb_version == "v1") {
-    return(.cb_get_filter_statistics_v1(cohort))
+    return(.cb_get_filter_statistics_v1(cohort, filter_id))
     
   } else if (cohort@cb_version == "v2") {
-    return(.cb_get_filter_statistics_v2(cohort))
+    return(.cb_get_filter_statistics_v2(cohort, filter_id))
     
   } else {
     stop('Unknown cohort browser version string ("cb_version"). Choose either "v1" or "v2".')

--- a/R/cb_json.R
+++ b/R/cb_json.R
@@ -10,6 +10,16 @@
 # }
 
 
+# unnest function to get a flat list of filters out of nested AND query operators
+.unnest_query<- function(q){
+  if (is.null(q$queries)){
+    return(list(q))
+  } else {
+    return(c(.unnest_query(q$queries[[1]]), .unnest_query(q$queries[[2]])))
+  }
+}
+
+
 #' only used for v1 endpoint - creates v1 search json using the v2 style query
 #' @param my_cohort A cohort object
 .get_search_json <- function(my_cohort){
@@ -20,16 +30,7 @@
     return(search)
   }
 
-  # unnest function to get a flat list of filters out of nested AND query operators
-  unnest <- function(q){
-    if (is.null(q$queries)){
-      return(list(q))
-    } else {
-      return(c(unnest(q$queries[[1]]), unnest(q$queries[[2]])))
-      }
-    }
-  
-  unnested <- unnest(my_cohort@query)
+  unnested <- .unnest_query(my_cohort@query)
   
   for (filter in unnested){
     if (is.null(filter$value$from)){

--- a/R/cb_json.R
+++ b/R/cb_json.R
@@ -12,10 +12,17 @@
 
 # unnest function to get a flat list of filters out of nested AND query operators
 .unnest_query<- function(q){
-  if (is.null(q$queries)){
+  if (is.null(q$queries)) {
     return(list(q))
-  } else {
+    
+  } else if (length(q$queries) == 1) {
+    return(.unnest_query(q$queries[[1]]))
+    
+  } else if (length(q$queries) == 2) {
     return(c(.unnest_query(q$queries[[1]]), .unnest_query(q$queries[[2]])))
+    
+  } else {
+    stop("Too many queries in operator.")
   }
 }
 


### PR DESCRIPTION
## This PR does the following:

+ it makes the `unnest()` function previously defined and used inside `cb_json.R/.get_search_json()` a globally accessible function for use elsewhere as a helper function named `.unnest_query()`
+ It adds the function `.cb_get_filter_statistics_v2()` and renames the old `cb_get_filter_statistics()` to `.cb_get_filter_statistics_v1()`.
+ The exported function ` cb_get_filter_statistics()` now calls `.cb_get_filter_statistics_v1()` or `.cb_get_filter_statistics_v2()` depending on the CB version of the cohort it is given.

## Testing

Get the package from the PR branch:
```shell
> git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
> cd cloudos
> git checkout update-cb_get_filter_statistics
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> library(cloudos)
> cloudos_configure(base_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

Test that you are able to generate stats tables with a filter ID and a cohort:

```R
> cohortv1 <- cb_load_cohort("60deee78f97e550eda221fee", cb_version="v1")
> cb_get_filter_statistics(cohortv1, 4)
# A tibble: 3 x 3
  `_id`         number total
  <chr>          <int> <int>
1 Cancer          8674 44668
2 Rare Diseases  35993 44668
3 male               1 44668

> cohortv2 <- cb_load_cohort("60edada49dd71b22256fd063", cb_version="v2")
> cb_get_filter_statistics(cohortv2, 4)
# A tibble: 1 x 3
  `_id`  number total
  <chr>   <int> <int>
1 Cancer   4151  4151
```
