### PR TITLE
update cb_apply_filter to CBv2  & new cohort class

### DIFF
--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -1,79 +1,138 @@
-.build_filter_body <- function(filter_query) {
+.simple_query_body_v1 <- function(simple_query) {
+  filter_list <- list()
   
-  filter_list_all <- c()
-  for(n in 1:length(filter_query)){
-    filter <- filter_query[[n]]
-    filter_id <- as.numeric(names(filter_query)[n])
+  for(n in seq_len(length(simple_query))){
+    
+    filter <- simple_query[[n]]
+    filter_id <- as.numeric(names(simple_query)[n])
+    
     if(is.list(filter)){
-      #print("range")
-      filter_list <- list(list("fieldId" = jsonlite::unbox(filter_id),
-                                                    "instance" = c(0),
-                                                    "range" = list("from" = jsonlite::unbox(filter$from),
-                                                                   "to" = jsonlite::unbox(filter$to)
-                                                    )))
-      }
-    if(!is.list(filter)){
-      #print("value")
-      filter_list <- list(list("fieldId" = jsonlite::unbox(filter_id),
-                                                    "instance" = c(0),
-                                                    "value" = filter
-      ))
-      }
-    filter_list_all <- c(filter_list_all, filter_list)
+      # # filter has a range
+      f <- list("fieldId" = filter_id,
+                "instance" = list("0"),
+                "range" = list(
+                  "from" = filter$from,
+                  "to" = filter$to
+                ))
+      filter_list <- c(filter_list, list(f))
+      
+    } else {
+      # filter has values not range
+      f <- list("fieldId" = filter_id,
+                "instance" = list("0"),
+                "value" =  c(list(),filter))
+      filter_list <- c(filter_list, list(f))
+    }
   }
-  return(filter_list_all)
+  
+  return(filter_list)
 }
 
-.get_existing_filter_body <- function(my_cohort_info) {
+
+.existing_query_body_v1 <- function(cohort) {
+  filter_list <- list()
   
-  filter_list_all <- c()
-  for(n in 1:length(my_cohort_info$moreFields)){
-    more_fields <- my_cohort_info$moreFields[[n]]
-    filter_id <- more_fields$fieldId
-    if("range" %in% names(more_fields)){
-      #print("range")
-      filter_list <- list(list("fieldId" = jsonlite::unbox(more_fields$fieldId),
-                               "instance" = c(0),
-                               "range" = list("from" = jsonlite::unbox(more_fields$range$from),
-                                              "to" = jsonlite::unbox(more_fields$range$to)
-                               )))
+  unnested <- .unnest_query(cohort@query)
+  for (filter in unnested){
+    
+    if (!is.null(filter$value$from)){
+      # filter has a range
+      f <- list("fieldId" = filter$field,
+                "instance" = filter$instance,
+                "range" = list(
+                  "from" = filter$value$from,
+                  "to" = filter$value$to
+                ))
+      filter_list <- c(filter_list, list(f))
+      
+    } else if (!is.null(filter$value)){
+      # filter has values but not a range
+      f <-list("fieldId" = filter$field,
+               "instance" = filter$instance,
+               "value" = filter$value)
+      filter_list <- c(filter_list, list(f))
     }
-    if("value" %in% names(more_fields)){
-      #print("value")
-      filter_list <- list(list("fieldId" = jsonlite::unbox(more_fields$fieldId),
-                               "instance" = c(0),
-                               "value" = unlist(more_fields$value)
-      ))
-    }
-    filter_list_all <- c(filter_list_all, filter_list)
   }
-  return(filter_list_all)
+  
+  return(filter_list)
 }
+
+
+.simple_query_body_v2 <- function(simple_query) {
+  andop <- list("operator" = "AND",
+                "queries" = list())
+  
+  l <- length(simple_query)
+  query <- list()
+  
+  if (l > 0){
+    query <- andop
+    query$queries <- list(list("field" = as.numeric(names(simple_query)[l]),
+                               "instance" = list("0"),
+                               "value" = c(list(), simple_query[[l]])))
+  }
+  
+  if (l > 1){
+    query$queries <- list(list("field" = as.numeric(names(simple_query)[l-1]),
+                               "instance" = list("0"),
+                               "value" = c(list(), simple_query[[l-1]])),
+                          query$queries[[1]])
+  }
+  
+  if (l > 2){
+    for (i in (l-2):1){
+      new_query <- andop
+      new_query$queries <- list(list("field" = as.numeric(names(simple_query)[i]),
+                                     "instance" = list("0"),
+                                     "value" = c(list(), simple_query[[i]])),
+                                query)
+      query <- new_query
+    }
+  }
+  
+  return(query)
+}
+
+
+.adv_query_body_v2 <- function(adv_query) {
+  # recursive function to reformat adv_query list into an api compliant query
+  reformat <- function(filter){
+    # TODO add error checking for operator type
+    if (is.null(filter$queries)){
+    filter <- list("field" = filter$id,
+              "instance" = list("0"),
+              "value" = c(list(), filter$value))
+    return(filter)
+    
+    } else {
+    filter$queries <- lapply(filter$queries, reformat)
+    return(filter)
+    
+    }
+  }
+  
+  query <- reformat(adv_query)
+  return(query)
+}
+
+
+.existing_query_body_v2 <- function(cohort) {
+  return(cohort@query)
+}
+
 
 .build_column_body <- function(column_ids) {
-  
   column_body_all <- c()
-  for(i in 1:length(column_ids)){
-    column_body_temp <- list("id" = jsonlite::unbox(column_ids[i]),
-                             "instance" = jsonlite::unbox(0),
-                             "array" = list("type" = jsonlite::unbox("exact"),
-                                            "value" = jsonlite::unbox(0)))
+  for(id in column_ids){
+    column_body_temp <- list("id" = id,
+                             "instance" = "0",
+                             "array" = list("type" = "exact",
+                                            "value" = 0))
     column_body_all <- c(column_body_all, list(column_body_temp))
   }
   return(column_body_all)
 }
 
-.get_existing_columns_body <- function(my_cohort_info){
-  column_body_all <- c()
-  for(i in length(my_cohort_info$columns)){
-    column_body_temp <- list("id" = jsonlite::unbox(my_cohort_info$columns[[i]]$id),
-                             "instance" = jsonlite::unbox(my_cohort_info$columns[[i]]$instance),
-                             "array" = list("type" = jsonlite::unbox(my_cohort_info$columns[[i]]$array$type),
-                                            "value" = jsonlite::unbox(my_cohort_info$columns[[i]]$array$value)))
-    column_body_all <- c(column_body_all, list(column_body_temp))
-  }
-  return(column_body_all)
-}
 
 #' @title Apply a Filter
 #'
@@ -81,7 +140,8 @@
 #'
 #' @param cohort A cohort object. (Required)
 #' See constructor function \code{\link{cb_create_cohort}} or \code{\link{cb_load_cohort}}
-#' @param filter_query Phenotypic filter query. 
+#' @param simple_query Phenotypic filter query. 
+#' @param adv_query Advanced phenotypic filter query (can include logical operators).
 #' @param column_ids Filter IDs as column in the table
 #' @param keep_existing_filter If wants to keep existing filters (Default: TRUE)
 #' @param keep_existing_columns If wants to keep existing columns (Default: TRUE)
@@ -90,40 +150,86 @@
 #' 
 #' @examples
 #' \dontrun{
-#' my_cohort <- cb_load_cohort(cohort_id = "5f9af3793dd2dc6091cd17cd")
+#' my_cohort <- cb_load_cohort(cohort_id = "5f9af3793dd2dc6091cd17cd", cb_version = "v1")
 #' cb_apply_filter(my_cohort,
-#'                 filter_query = list("22" = list("from" = "2015-05-13", "to" = "2016-04-29"),
+#'                 simple_query = list("22" = list("from" = "2015-05-13", "to" = "2016-04-29"),
 #'                                     "50" = c("Father", "Mother")) )
+#' 
+#' my_cohort <- cb_load_cohort(cohort_id = "5f9af3793dd2dc6091cd17cd", cb_version = "v2")
+#' adv_query <- list(
+#'   "operator" = "AND",
+#'   "queries" = list(
+#'     list( "id" = 22, "value" = list("from"="2015-05-13", "to"="2016-04-29")),
+#'     list(
+#'       "operator" = "OR",
+#'       "queries" = list(
+#'         list("id" = 32, "value" = c("Cancer", "Rare Diseases")),
+#'         list("id" = 14, "value" = "Yes")
+#'       )
+#'     )
+#'   )
+#' )
+#' cb_apply_filter(my_cohort, adv_query = adv_query)
+#' 
 #'}
 #'
 #' @export
 cb_apply_filter <- function(cohort, 
-                            filter_query,
+                            simple_query,
+                            adv_query,
+                            column_ids,
+                            keep_existing_filter = TRUE,
+                            keep_existing_columns = TRUE){
+  
+  if (cohort@cb_version == "v1"){
+    if (!missing(adv_query)) stop("Advanced queries are not compatible with Cohort Browser v1.")
+    return(.cb_apply_filter_v1(cohort = cohort,
+                               simple_query =  simple_query,
+                               column_ids = column_ids,
+                               keep_existing_filter = keep_existing_filter,
+                               keep_existing_columns = keep_existing_columns))
+    
+  } else if (cohort@cb_version == "v2") {
+    return(.cb_apply_filter_v1(cohort = cohort,
+                               simple_query =  simple_query,
+                               adv_query = adv_query,
+                               column_ids = column_ids,
+                               keep_existing_filter = keep_existing_filter,
+                               keep_existing_columns = keep_existing_columns))
+        
+  } else {
+    stop('Unknown cohort browser version string ("cb_version"). Choose either "v1" or "v2".')
+  }
+}
+
+
+.cb_apply_filter_v1 <- function(cohort, 
+                            simple_query,
                             column_ids,
                             keep_existing_filter = TRUE,
                             keep_existing_columns = TRUE) {
   
-  # get info about existing columns and fields
-  my_cohort_info <- .get_cohort_info(cohort_id = cohort@id)
-  
   # cohort columns
-  all_columns <- c()
+  all_columns <- list()
   if(!missing(column_ids)){
     all_columns <- .build_column_body(column_ids)
   }
   if(keep_existing_columns){
-    existing_columns <- .get_existing_columns_body(my_cohort_info)
+    existing_ids <- sapply(cohort@columns, function(col){col$field$id})
+    existing_columns <- .build_column_body(existing_ids)
     all_columns <- c(existing_columns, all_columns)
   }
   
   # cohort filters
-  all_filters <- c()
-  if(!missing(filter_query)){
-    all_filters <- .build_filter_body(filter_query)
-  }
+  all_filters <- list()
   if(keep_existing_filter){
-    existing_filters <- .get_existing_filter_body(my_cohort_info)
-    all_filters <- c(existing_filters, all_filters)
+    existing_filters <- .existing_query_body_v1(cohort)
+    all_filters <- c(all_filters, existing_filters)
+  }
+  
+  if(!missing(simple_query)){
+    simple_q_filters <- .simple_query_body_v1(simple_query)
+    all_filters <- c(all_filters, simple_q_filters)
   }
   
   # prepare request body
@@ -136,14 +242,89 @@ cb_apply_filter <- function(cohort,
   r <- httr::PUT(url,
                   .get_httr_headers(cloudos$token),
                   query = list("teamId" = cloudos$team_id),
-                  body = jsonlite::toJSON(r_body),
+                  body = jsonlite::toJSON(r_body, auto_unbox = T),
                   encode = "raw"
   )
   httr::stop_for_status(r, task = NULL)
   # parse the content
   res <- httr::content(r)
-  return(message("Filtter applied sucessfully, Current number of Participants - ", res$numberOfParticipants))
+  return(message("Filter applied sucessfully, Current number of Participants - ", res$numberOfParticipants))
 }
+
+
+.cb_apply_filter_v2 <- function(cohort, 
+                            simple_query,
+                            adv_query,
+                            column_ids,
+                            keep_existing_filter = TRUE,
+                            keep_existing_columns = TRUE) {
+  
+  if (!missing(adv_query) & !missing(simple_query)) stop("Cannot use advanced and simple queries at the same time.")
+  
+  # cohort columns
+  all_columns <- c()
+  if (!missing(column_ids)) {
+    all_columns <- .build_column_body(column_ids)
+  }
+  if (keep_existing_columns) {
+    existing_ids <- sapply(cohort@columns, function(col){col$field$id})
+    existing_columns <- .build_column_body(existing_ids)
+    all_columns <- c(existing_columns, all_columns)
+  }
+  
+  
+  # prepare request body
+  r_body <- list("name" = cohort@name,
+                 "description" = cohort@desc,
+                 "columns" = all_columns)
+  
+  # cohort query
+  
+  # get new query to apply
+  if (!missing(simple_query)) {
+    new_query <- .simple_query_body_v2(simple_query)
+  } else if (!missing(adv_query)) {
+    new_query <- .adv_query_body_v2(adv_query)
+  } else {
+    new_query <- list()
+  }
+  
+  if (keep_existing_filter) {
+    existing_query <- .existing_query_body_v2(cohort)
+  } else {
+    existing_query <- list()
+  }
+  
+  # combine queries depending on whether they are empty or not
+  qs <- list(existing_query, new_query)
+  qs <- qs[lapply(qs, length) > 0]
+  
+  # add query to r_body if appropriate
+  if (length(qs) == 2) {
+    r_body$query <- list("operator" = "AND",
+                         "queries" = qs)
+      
+  } else if (length(qs) == 1) {
+    r_body$query <- qs[[1]]
+      
+  }
+
+  cloudos <- .check_and_load_all_cloudos_env_var()
+  # make request
+  url <- paste(cloudos$base_url, "v2/cohort", cohort@id, sep = "/")
+  r <- httr::PUT(url,
+                  .get_httr_headers(cloudos$token),
+                  query = list("teamId" = cloudos$team_id),
+                  body = jsonlite::toJSON(r_body, auto_unbox = T),
+                  encode = "raw"
+  )
+  httr::stop_for_status(r, task = NULL)
+  # parse the content
+  res <- httr::content(r)
+  return(message("Filter applied sucessfully, Current number of Participants - ", res$numberOfParticipants))
+}
+
+
 
 #' @title Dry run for \code{\link{cb_apply_filter}}
 #'
@@ -151,7 +332,7 @@ cb_apply_filter <- function(cohort,
 #'
 #' @param cohort A cohort object. (Required)
 #' See constructor function \code{\link{cb_create_cohort}} or \code{\link{cb_load_cohort}}
-#' @param filter_query Phenotypic filter query. 
+#' @param simple_query Phenotypic filter query. 
 #'
 #' @return A data frame.
 #' 
@@ -159,14 +340,14 @@ cb_apply_filter <- function(cohort,
 #' \dontrun{
 #' my_cohort <- cb_load_cohort(cohort_id = "5f9af3793dd2dc6091cd17cd")
 #' cb_apply_filter_dry_run(my_cohort,
-#'                         filter_query = list("22" = list("from" = "2015-05-13", "to" = "2016-04-29"),
+#'                         simple_query = list("22" = list("from" = "2015-05-13", "to" = "2016-04-29"),
 #'                                             "50" = c("Father", "Mother")) )
 #'}
 #'
 #' @export
-cb_apply_filter_dry_run <- function(cohort, filter_query) {
+cb_apply_filter_dry_run <- function(cohort, simple_query) {
   # prepare request body
-  r_body <- list("moreFilters" = .build_filter_body(filter_query))
+  r_body <- list("moreFilters" = .build_filter_body(simple_query))
 
   # add additional content
   r_body[["ids"]] = list()

--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -283,6 +283,7 @@ cb_apply_filter <- function(cohort,
   # get new query to apply
   if (!missing(simple_query)) {
     new_query <- .simple_query_body_v2(simple_query)
+    r_body$type <- "advanced"
   } else if (!missing(adv_query)) {
     new_query <- .adv_query_body_v2(adv_query)
     r_body$type <- "advanced"

--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -190,7 +190,7 @@ cb_apply_filter <- function(cohort,
                                keep_existing_columns = keep_existing_columns))
     
   } else if (cohort@cb_version == "v2") {
-    return(.cb_apply_filter_v1(cohort = cohort,
+    return(.cb_apply_filter_v2(cohort = cohort,
                                simple_query =  simple_query,
                                adv_query = adv_query,
                                column_ids = column_ids,

--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -285,6 +285,7 @@ cb_apply_filter <- function(cohort,
     new_query <- .simple_query_body_v2(simple_query)
   } else if (!missing(adv_query)) {
     new_query <- .adv_query_body_v2(adv_query)
+    r_body$type <- "advanced"
   } else {
     new_query <- list()
   }
@@ -321,7 +322,7 @@ cb_apply_filter <- function(cohort,
   httr::stop_for_status(r, task = NULL)
   # parse the content
   res <- httr::content(r)
-  return(message("Filter applied sucessfully, Current number of Participants - ", res$numberOfParticipants))
+  return(message("Filter applied sucessfully."))
 }
 
 

--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -1,3 +1,7 @@
+# 5 helper functions below. Each converts the different structures of 
+# query data into either CBv1 or CBv2 query JSONs for use in cb_apply_filter()
+
+# converts a simple query into CBv1 style query JSON
 .simple_query_body_v1 <- function(simple_query) {
   filter_list <- list()
   
@@ -29,6 +33,8 @@
 }
 
 
+# converts the CBv2 style cohort@query data into CBv1 style query JSON
+# this is very similar but not quite the same as .get_search_json()
 .existing_query_body_v1 <- function(cohort) {
   filter_list <- list()
   
@@ -58,6 +64,8 @@
 }
 
 
+# converts a simple query into CBv2 style query JSON
+# conversion is achieved by creating a nested series of AND nodes (similar to .v1_query_to_v2())
 .simple_query_body_v2 <- function(simple_query) {
   andop <- list("operator" = "AND",
                 "queries" = list())
@@ -94,6 +102,7 @@
 }
 
 
+# converts an advanced query into CBv2 style query JSON
 .adv_query_body_v2 <- function(adv_query) {
   # recursive function to reformat adv_query list into an api compliant query
   reformat <- function(filter){
@@ -116,11 +125,14 @@
 }
 
 
+# created as a function for consistency 
 .existing_query_body_v2 <- function(cohort) {
   return(cohort@query)
 }
 
 
+# takes a single int ID or a vector of int IDs and builds 
+# a JSON array for use in cb_apply_filter()
 .build_column_body <- function(column_ids) {
   column_body_all <- c()
   for(id in column_ids){


### PR DESCRIPTION
## This PR does the following:

A big rewrite of `cb_apply_filter()` and its helper functions so that it can use the new version of the cohort class for CBv1 (via `cb_apply_filter_v1()`) and is functional with CBv2 (via `cb_apply_filter_v2()`).

+ The parameter/object referred to as `filter_query` in the old code is now referred to as a `simple_query`. For converting a simple query into a CBv1 api structure `.simple_query_body_v1()` is used. This is just a renamed and neatened up version of the old `.build_filter_body()` function.
+ `cb_apply_filter()` now accepts a new type of query called an advanced query with the parameter `adv_query`. Advanced queries only work with CBv2 and can use logical operators 'AND', 'OR', 'NOT'. An example is given in the function documentation. These follow a structure that is a simplified form of the CBv2 query api structure. `.adv_query_body_v2()` handles converting from the simplified structure into the full CB api structure.
+ Simple_queries can still be used with CBv2 cohorts and are converted to CBv2 style queries by the function `.simple_query_body_v2()`.
+ `.existing_query_body_v1()` is used for converting the`cohort@queries` objects into CBv1 style filters (similar code to `.get_search_json()`)
+ `.build_column_body()` has been neatened up and is now used for its original function but also in place of `.get_existing_columns_body()` which is no longer needed.


## Testing

Get the package from the PR branch:
```shell
> git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
> cd cloudos
> git checkout update-cb_apply_filter
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> library(cloudos)
> cloudos_configure(base_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

Test with CBv1 cohort.
```R
> simple_query = list("4" = "Cancer",
+          "13" = list("from"="2016-01-21", "to"="2017-02-13"))
> cohortv1 <- cb_create_cohort("test-apply-02", cb_version = "v1")
Cohort created successfully.
> cohortv1@id
[1] "60f045f9bcb3c13892ade4ad"
> cb_apply_filter(cohortv1, simple_query = simple_query, column_ids = 14, keep_existing_filter = F, keep_existing_columns = F)
Filter applied sucessfully, Current number of Participants - 4154
# check in web-ui to confirm new filters are applied to cohort and columns are the ones selected http://dev-gel.lifebit.ai/app/cohort-browser/60f045f9bcb3c13892ade4ad

# update the cohort object to sync up the changes we made
> cohortv1 <- cb_load_cohort(cohortv1@id, cb_version = cohortv1@cb_version)

> cb_apply_filter(cohortv1, simple_query = list("56" = "Adult C1"), column_ids = 56, keep_existing_filter = T, keep_existing_columns = T)
Filter applied sucessfully, Current number of Participants - 3886
# check in web-ui to confirm new filters are applied to cohort and columns are the ones selected http://dev-gel.lifebit.ai/app/cohort-browser/60f045f9bcb3c13892ade4ad
```

Test with CBv2 cohort.
```R
> adv_query <- list(
+   "operator" = "AND",
+   "queries" = list(
+     list( "id" = 13, "value" = list("from"="2016-01-21", "to"="2017-02-13")),
+     list(
+       "operator" = "AND",
+       "queries" = list(
+         list("id" = 4, "value" = "Cancer"),
+         list("id" = 21, "value" = "Consenting")
+       )
+     )
+   )
+ )
> cohortv2 <- cb_create_cohort("test-apply-06", cb_version = "v2")
Cohort created successfully.
> cohortv2@id
[1] "60f05b2bb356e94202d4822d"
> cb_apply_filter(cohortv2, adv_query = adv_query, column_ids = 14, keep_existing_filter = F, keep_existing_columns = F)
Filter applied sucessfully.
# check in web-ui to confirm new filters are applied to cohort and columns are the ones selected http://dev-gel.lifebit.ai/app/cohort-browser-new/60f05b2bb356e94202d4822d

# update the cohort object to sync up the changes we made
> cohortv2 <- cb_load_cohort(cohortv2@id, cb_version = cohortv2@cb_version)

> cb_apply_filter(cohortv2, simple_query = list("56" = "Adult C1"), column_ids = 56, keep_existing_filter = T, keep_existing_columns = T)
Filter applied sucessfully.
# check in web-ui to confirm new filters are applied to cohort and columns are the ones selected http://dev-gel.lifebit.ai/app/cohort-browser-new/60f05b2bb356e94202d4822d
```

The number of participants after the filter has been applied is no longer returned by CBv2 api.