### PR TITLE
Deprecate cb_apply_filter_dry_run

### DIFF
--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -360,8 +360,13 @@ cb_apply_filter <- function(cohort,
 #'
 #' @export
 cb_apply_filter_dry_run <- function(cohort, simple_query) {
+
+  .Deprecated("cb_participant_count")
+
+  if (cohort@cb_version != "v1") stop("This function is only compatible with Cohort Browser version v1 cohorts.")
+
   # prepare request body
-  r_body <- list("moreFilters" = .build_filter_body(simple_query))
+  r_body <- list("moreFilters" = .simple_query_body_v1(simple_query))
 
   # add additional content
   r_body[["ids"]] = list()
@@ -373,7 +378,7 @@ cb_apply_filter_dry_run <- function(cohort, simple_query) {
   r <- httr::POST(url,
                   .get_httr_headers(cloudos$token),
                   query = list("teamId" = cloudos$team_id),
-                  body = jsonlite::toJSON(r_body),
+                  body = jsonlite::toJSON(r_body, auto_unbox = T),
                   encode = "raw"
   )
   httr::stop_for_status(r, task = NULL)


### PR DESCRIPTION
## This PR does the following:

The endpoint for `cb_apply_filter_dry_run()` is used for something completely different in CBv2 so this function is not being upgraded to CBv2. The information returned by this function can be better returned by `cb_participant_count()` which works for both CBv1 and CBv2.

+ Adds check to ensure only CBv1 cohort is being used with `cb_apply_filter_dry_run()`.
+ Adds deprecation warning upon use of `cb_apply_filter_dry_run()`.
+ Updates `cb_apply_filter_dry_run()` to work with updated helper function `.simple_query_body_v1`

## Testing

Get the package from the PR branch:
```shell
> git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
> cd cloudos
> git checkout deprecate-cb_apply_filter_dry_run
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> library(cloudos)
> cloudos_configure(base_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

Test that deprecation warning is produced and the information is returned for CBv1 and that an error is produced for CBv2.

```R
> cohortv1 <- cb_load_cohort("60f59b1115f2085c947db103", cb_version="v1")
> cb_apply_filter_dry_run(cohortv1, list("4" = "Cancer"))
     cohortId                   markers filters _id                        numberOfParticipants
data "60f59b1115f2085c947db103" list,0  list,1  "60f841ded9b85c1630413698" 8673                
Warning message:
'cb_apply_filter_dry_run' is deprecated.
Use 'cb_participant_count' instead.
See help("Deprecated") 

> cb_apply_filter_dry_run(cohortv2, list("4" = "Cancer"))
Error in cb_apply_filter_dry_run(cohortv2, list(`4` = "Cancer")) : 
  This function is only compatible with Cohort Browser version v1 cohorts.
In addition: Warning message:
'cb_apply_filter_dry_run' is deprecated.
Use 'cb_participant_count' instead.
See help("Deprecated") 
```

