### PR TITLE
Add function to reformat queries and prevent UI error

### DIFF
--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -151,7 +151,12 @@
   
   if(!is.list(x)) return(x)
   
-  if(!is.null(x$operator) & ifelse(is.null(x$operator), "", x$operator) != "NOT" & length(x$queries) == 1 & starting_depth > 1) return(x$queries[[1]])
+  if(
+    starting_depth > 1 &
+    !is.null(x$operator) & 
+    ifelse(is.null(x$operator), "", x$operator) != "NOT" & 
+    length(x$queries) == 1
+  ) return(x$queries[[1]])
   
   lapply(x, .extract_single_nodes, starting_depth)
   

--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -151,7 +151,7 @@
   
   if(!is.list(x)) return(x)
   
-  if(!is.null(x$operator) & length(x$queries) == 1 & starting_depth > 1) return(x$queries[[1]])
+  if(!is.null(x$operator) & ifelse(is.null(x$operator), "", x$operator) != "NOT" & length(x$queries) == 1 & starting_depth > 1) return(x$queries[[1]])
   
   lapply(x, .extract_single_nodes, starting_depth)
   

--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -160,7 +160,7 @@
     !is.null(x$operator) & 
     !identical(x$operator, "NOT") & 
     length(x$queries) == 1
-  ) return(x$queries[[1]])
+  ) return(.extract_single_nodes(x$queries[[1]], starting_depth))
   
   lapply(x, .extract_single_nodes, starting_depth)
   

--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -145,6 +145,10 @@
   return(column_body_all)
 }
 
+# takes any CB v2 query and recursively looks for subqueries where an
+# AND/OR operator is applied to a single condition and removes the operator. 
+# When calling this function, starting_depth should be left as default (0). Its
+# value is updated during recursion
 .extract_single_nodes <- function(x, starting_depth = 0){
   
   starting_depth <- starting_depth + 1
@@ -154,7 +158,7 @@
   if(
     starting_depth > 1 &
     !is.null(x$operator) & 
-    ifelse(is.null(x$operator), "", x$operator) != "NOT" & 
+    !identical(x$operator, "NOT") & 
     length(x$queries) == 1
   ) return(x$queries[[1]])
   

--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -145,6 +145,17 @@
   return(column_body_all)
 }
 
+.extract_single_nodes <- function(x, starting_depth = 0){
+  
+  starting_depth <- starting_depth + 1
+  
+  if(!is.list(x)) return(x)
+  
+  if(!is.null(x$operator) & length(x$queries) == 1 & starting_depth > 1) return(x$queries[[1]])
+  
+  lapply(x, .extract_single_nodes, starting_depth)
+  
+}
 
 #' @title Apply a Filter
 #'
@@ -322,6 +333,8 @@ cb_apply_filter <- function(cohort,
     r_body$query <- qs[[1]]
       
   }
+  
+  r_body$query <- .extract_single_nodes(r_body$query)
 
   cloudos <- .check_and_load_all_cloudos_env_var()
   # make request

--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -326,6 +326,8 @@ cb_participant_count <-function(cohort,
   } else {
     r_body <- NULL
   }
+  
+  r_body <- .extract_single_nodes(r_body)
 
   cloudos <- .check_and_load_all_cloudos_env_var()
   # make request


### PR DESCRIPTION
## This PR does the following:

This PR fixes #47, where CB v2 queries containing a subquery where an `AND` or `OR` operator is applied to a single phenotype condition breaks the CB web UI. For example:

```json
{"name":"test-filter-all23","description":"","columns":[{"id":14,"instance":"0","array":{"type":"exact","value":0}}],"type":"advanced","query":{"operator":"AND","queries":[{"field":13,"instance":["0"],"value":{"from":"2016-01-21","to":"2017-02-13"}},{"operator":"AND","queries":[{"field":4,"instance":["0"],"value":["Cancer"]}]}]}} 
```

This is problematic because it is the default query structure when a `simple_query` is applied on top of an existing query with `keep_existing_filter = T`.

A non-exposed helper function, `.extract_single_nodes`, has been added to reformat such queries before sending the request in `cb_apply_filter`. For consistency, queries used in `cb_participant_count` are now also reformatted.

## Testing

Get the package from the PR branch:
```shell
> git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
> cd cloudos
> git checkout fix_single_query_nodes
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> library(cloudos)
> cloudos_configure(base_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

To test that the revised code will accept the query corresponding to the above json:

```R
adv_query <- list(
  "operator" = "AND",
  "queries" = list(
    list("id" = 13, "value" = list("from"="2016-01-21", "to"="2017-02-13")),
    list(
      "operator" = "AND",
      "queries" = list(
        list("id" = 4, "value" = "Cancer")
        )
      )
    )
)

cohortv2 <- cb_load_cohort("60f8185cd9b85c1630413692", cb_version="v2")

cb_participant_count(cohortv2, adv_query = adv_query, keep_existing_filter = F)

cb_apply_filter(cohortv2, adv_query = adv_query, keep_existing_filter = F)
```

To test that subqueries using `NOT` operators are not affected:

```R
adv_query <- list(
  "operator" = "AND",
  "queries" = list(
    list("id" = 13, "value" = list("from"="2016-01-21", "to"="2017-02-13")),
    list(
      "operator" = "NOT",
      "queries" = list(
        list("id" = 4, "value" = "Cancer")
        )
      )
    )
)

cohortv2 <- cb_load_cohort("60f8185cd9b85c1630413692", cb_version="v2")

cb_participant_count(cohortv2, adv_query = adv_query, keep_existing_filter = F)

cb_apply_filter(cohortv2, adv_query = adv_query, keep_existing_filter = F)
```
