### PR TITLE
Fix empty numberOfParticpants field in .cb_apply_filter_v2

### DIFF
--- a/R/cb_filter_apply.R
+++ b/R/cb_filter_apply.R
@@ -310,6 +310,13 @@ cb_apply_filter <- function(cohort,
                  "description" = cohort@desc,
                  "columns" = all_columns)
   
+  # get count of particpants if query is applied
+  no_participants <- cb_participant_count(cohort,
+                                          simple_query = simple_query,
+                                          adv_query = adv_query,
+                                          keep_existing_filter = keep_existing_filter)
+  r_body$numberOfParticipants <- no_participants$count
+  
   # cohort query
   
   # get new query to apply

--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -317,17 +317,18 @@ cb_participant_count <-function(cohort,
   if (length(qs) == 2) {
     r_body <- list("query" = list("operator" = "AND",
                                   "queries" = qs))
+    r_body$query <- .extract_single_nodes(r_body$query)
     r_body <- jsonlite::toJSON(r_body, auto_unbox = T)
     
   } else if (length(qs) == 1) {
     r_body <- list("query" = qs[[1]])
+    r_body$query <- .extract_single_nodes(r_body$query)
     r_body <- jsonlite::toJSON(r_body, auto_unbox = T)
     
   } else {
     r_body <- NULL
   }
   
-  r_body <- .extract_single_nodes(r_body)
 
   cloudos <- .check_and_load_all_cloudos_env_var()
   # make request


### PR DESCRIPTION
 ## This PR does the following:

+ Adds a `numberOfParticipants` field to the request in `.cb_apply_filter_v2` (by calling `cb_participant_count`). This ensures the field isn't left empty in the backend after a cohort is updated.
+ Fixes the order of when `.extract_single_nodes` is applied in `.cb_participant_count_v2`.
 
## Testing

Get the package from the PR branch:
```shell
> git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
> cd cloudos
> git checkout  fix-empty_numberofparticpants_field
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> library(cloudos)
> cloudos_configure(base_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

Test that Number of Particpants is shown correctly in the frontend:

```R
> cohortv2 <- cb_create_cohort("test-apply-345234", cb_version="v2")
Cohort created successfully.
> cohortv2@id
[1] "60fe88f5a4d79e3c38a8d0ec"
> .cb_apply_filter_v2(cohortv2, simple_query = list("56" = "Adult C1"))
Filter applied sucessfully.
# check in web-ui to confirm the "Number of participants" column does not have a blank entry for this cohort http://dev-gel.lifebit.ai/app/cohort-browser-new
```