### PR TITLE
Fix .cb_get_phenotype_statistics_v1

### DIFF
--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -113,7 +113,14 @@ cb_get_phenotype_statistics <- function(cohort, pheno_id ) {
   # make more_filters from cohort@query
   more_filters = list() 
   for (filter in .unnest_query(cohort@query)){
-    if (!is.null(filter$value)){
+    
+    if (!is.null(filter$value$from)){
+      # rename field to fieldId and value to range
+      names(filter)[names(filter) == "field"] <- "fieldId"
+      names(filter)[names(filter) == "value"] <- "range"
+      more_filters <- c(more_filters, list(filter))
+      
+    } else if (!is.null(filter$value)){
       # rename field to fieldId
       names(filter)[names(filter) == "field"] <- "fieldId"
       more_filters <- c(more_filters, list(filter))


### PR DESCRIPTION
 ## This PR does the following:

+ Fixes an error that occurs when `cb_get_phenotype_statisitics` is used on a CBv1 cohort (i.e. `.cb_get_phenotype_statistics_v1`) with a continuous phenotype in it's query.
 
## Testing

Get the package from the PR branch:
```shell
> git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
> cd cloudos
> git checkout  fix-empty_numberofparticpants_field
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> library(cloudos)
> cloudos_configure(base_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

Test that `cb_get_phenotype_statisitics` now works with CBv1 cohorts with continuous phenotypes in the query.

```R
> cohortv1 <- cb_create_cohort("iltest-gh", cb_version="v1")
Cohort created successfully.
> simple_query = list("4" = "Cancer",
+                     "13" = list("from"="2016-01-21", "to"="2017-02-13"))

> cb_apply_query(cohortv1, simple_query = simple_query, keep_query = F)
Query applied sucessfully, Current number of Participants - 4154

> cohortv1 <- cb_load_cohort(cohortv1@id, cb_version=cohortv1@cb_version)

> cb_get_phenotype_statistics(cohortv1, pheno_id = 21)
# A tibble: 2 x 3
  `_id`      number total
  <chr>       <int> <int>
1 Consenting   4151  4154
2 Unknown         3  4154
```