### PR TITLE
Fix empty query errors

### DIFF
--- a/R/cb_cohort_extract.R
+++ b/R/cb_cohort_extract.R
@@ -210,19 +210,21 @@ cb_get_participants_table <- function(cohort,
   }else{
     columns <- .get_column_json(cohort)
   }
+  
+  r_body <- list("criteria" = list("pagination" = list("pageNumber" = page_number,
+                                                       "pageSize" = page_size),
+                                   "cohortId" = cohort@id),
+                 "columns" = columns)
+  
+  if (length(cohort@query > 0)) r_body$query <- cohort@query
+  
   cloudos <- .check_and_load_all_cloudos_env_var()
   # make request
   url <- paste(cloudos$base_url, "v2/cohort/participants/search", sep = "/")
   r <- httr::POST(url,
                   .get_httr_headers(cloudos$token),
                   query = list("teamId" = cloudos$team_id),
-                  body = jsonlite::toJSON(
-                    list("criteria" = list("pagination" = list("pageNumber" = page_number,
-                                                               "pageSize" = page_size),
-                                           "cohortId" = cohort@id),
-                         "query" = cohort@query,
-                         "columns" = columns),
-                    auto_unbox = T),
+                  body = jsonlite::toJSON(r_body, auto_unbox = T),
                   encode = "raw")
   
   httr::stop_for_status(r, task = NULL)

--- a/R/cb_cohort_extract.R
+++ b/R/cb_cohort_extract.R
@@ -216,7 +216,7 @@ cb_get_participants_table <- function(cohort,
                                    "cohortId" = cohort@id),
                  "columns" = columns)
   
-  if (length(cohort@query > 0)) r_body$query <- cohort@query
+  if (length(cohort@query) > 0) r_body$query <- cohort@query
   
   cloudos <- .check_and_load_all_cloudos_env_var()
   # make request

--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -155,7 +155,7 @@ cb_get_phenotype_statistics <- function(cohort, pheno_id ) {
                  "filter" = list("instance" = list("0"))
                  )
   
-  if (length(cohort@query > 0)) r_body$query <- cohort@query
+  if (length(cohort@query) > 0) r_body$query <- cohort@query
   
   cloudos <- .check_and_load_all_cloudos_env_var()
   # make request

--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -152,9 +152,11 @@ cb_get_phenotype_statistics <- function(cohort, pheno_id ) {
 .cb_get_phenotype_statistics_v2 <- function(cohort, pheno_id) {
   # empty moreFilters returns all the filter values associated with a cohort for a filter
   r_body <- list("criteria" = list("cohortId" = cohort@id),
-                 "filter" = list("instance" = list("0")),
-                 "query" = cohort@query
+                 "filter" = list("instance" = list("0"))
                  )
+  
+  if (length(cohort@query > 0)) r_body$query <- cohort@query
+  
   cloudos <- .check_and_load_all_cloudos_env_var()
   # make request
   url <- paste(cloudos$base_url, "v2/cohort/filter", pheno_id, "data", sep = "/")


### PR DESCRIPTION
 ## This PR does the following:

+ Fixes an error that occurs when `cb_get_phenotype_statisitics` is used on a CBv2 cohort (i.e. `.cb_get_phenotype_statistics_v2`) with an empty query.
+ Fixes an error that occurs when `cb_get_participants_table` is used on a CBv2 cohort (i.e. `.cb_get_participants_table_v2`) with an empty query.
 
## Testing

Get the package from the PR branch:
```shell
> git clone 'https://github.com/lifebit-ai/cloudos.git'                                                                                                                                   
> cd cloudos
> git checkout  fix-empty_query_errors
```

In the cloudos directory enter an R session (or do so in Rstudio) and load the package + config:
```R
> devtools::install(".")
> library(cloudos)
> cloudos_configure(base_url = "http://demo2-cohortbrowser-lb-173894322.eu-west-1.elb.amazonaws.com/cohort-browser/", 
token = "...api token...",
team_id = "5f7c8696d6ea46288645a89f")
```

Test that `cb_get_phenotype_statisitics` now works with CBv1 cohorts with continuous phenotypes in the query.

```R
> cohort <- cb_create_cohort(cohort_name = "iltest-gh-02", cb_version="v2")
Cohort created successfully.
> 

> cb_get_phenotype_statistics(cohort = cohort, pheno_id = 10)
# A tibble: 2 x 3
  `_id`  number total
  <chr>   <int> <int>
1 Male    20922 44662
2 Female  23740 44662

> cb_get_participants_table(cohort = cohort)
       EID     Programme         Handling gmc Year of birth                 Participant ethnic category
1  1000002 Rare Diseases        West Midlands          1982                              White: British
2  1000020 Rare Diseases         North Thames          1970                                  Not Stated
3  1000035 Rare Diseases South West Peninsula          1944                      Mixed: White and Asian
4  1000061 Rare Diseases         North Thames          1971                                  Not Stated
5  1000232        Cancer           North West          1934                              White: British
6  1000233 Rare Diseases         North Thames          2016                                  Not Stated
7  1000289 Rare Diseases         North Thames          1950                              White: British
8  1000357 Rare Diseases         North Thames          2009                              White: British
9  1000372 Rare Diseases           North West          1973 Other Ethnic Groups: Any other ethnic group
10 1000397 Rare Diseases         North Thames          1999                      Mixed: White and Asian
   Participant karyotypic sex Participant type
1                          Xy         Relative
2                     Unknown         Relative
3                Not Supplied         Relative
4                Not Supplied         Relative
5                          NA               NA
6                Not Supplied          Proband
7                Not Supplied          Proband
8                Not Supplied          Proband
9                Not Supplied         Relative
10               Not Supplied          Proband

```