### PR TITLE
Fix error in cb_get_phenotype_statistics() when phenotype values are not all strings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cloudos
 Title: R Client Library for CloudOS
-Version: 0.2.0.9001
+Version: 0.2.0.9002
 Authors@R: c(
     person(given = "Sangram Keshari",
            family = "Sahu",

--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -253,6 +253,7 @@ cb_get_phenotype_statistics <- function(cohort, pheno_id, max_depth = Inf, page_
   
   if (is.null(res_data[[1]]$children)) {
     # not nested phenotype
+    res_data <- lapply(res_data, function(x){x$`_id` <- as.character(x$`_id`); x)})
     res_df <- dplyr::bind_rows(res_data)
     res_df <- dplyr::rename(res_df, value = `_id`, count = number) %>% select(c('value', 'count'))
   } else {

--- a/R/cb_filter_explore.R
+++ b/R/cb_filter_explore.R
@@ -253,7 +253,7 @@ cb_get_phenotype_statistics <- function(cohort, pheno_id, max_depth = Inf, page_
   
   if (is.null(res_data[[1]]$children)) {
     # not nested phenotype
-    res_data <- lapply(res_data, function(x){x$`_id` <- as.character(x$`_id`); x)})
+    res_data <- lapply(res_data, function(x){x$`_id` <- as.character(x$`_id`); x})
     res_df <- dplyr::bind_rows(res_data)
     res_df <- dplyr::rename(res_df, value = `_id`, count = number) %>% select(c('value', 'count'))
   } else {


### PR DESCRIPTION
 ## This PR does the following:

+ `cb_get_phenotype_stats()` no longer throws an error when a phenotype has a mix of types for in the `_id` field of the data in the API response.


## Testing
This error was encountered on GEL Production cloudos with specific phenotypes and the branch has since been tested in the same environment and resolves the issue.